### PR TITLE
Respect "Share Customer Accounts" -> "Per Website" config

### DIFF
--- a/app/code/local/Magpleasure/Assignorder/Block/Adminhtml/Customer/Grid.php
+++ b/app/code/local/Magpleasure/Assignorder/Block/Adminhtml/Customer/Grid.php
@@ -77,8 +77,13 @@ class Magpleasure_Assignorder_Block_Adminhtml_Customer_Grid extends Mage_Adminht
             if ($customerId = $order->getCustomerId()) {
                 $collection->addFieldToFilter('entity_id', array('neq' => $customerId));
             }
+            if (Mage::getSingleton('customer/config_share')->isWebsiteScope()) {
+                $collection->addFieldToFilter('website_id', array('eq' => $order->getStore()->getWebsiteId()));
+            }
         }
-
+        else if ($websiteId = Mage::getSingleton('adminhtml/session')->getAssignorderWebsiteId()) {
+            $collection->addFieldToFilter('website_id', array('eq' => $websiteId));
+        }
 
         $this->setCollection($collection);
 

--- a/app/code/local/Magpleasure/Assignorder/Block/Adminhtml/Customer/Grid.php
+++ b/app/code/local/Magpleasure/Assignorder/Block/Adminhtml/Customer/Grid.php
@@ -50,9 +50,11 @@ class Magpleasure_Assignorder_Block_Adminhtml_Customer_Grid extends Mage_Adminht
 
     public function getOrder()
     {
+        if ( ! empty($this->_order)) { return $this->_order; }
         if ($orderId = $this->getRequest()->getParam('order_id')) {
 
             if ($order = $this->_helper()->_order()->getOrder($orderId)) {
+                $this->_order = $order;
                 return $order;
             }
         }
@@ -182,6 +184,9 @@ class Magpleasure_Assignorder_Block_Adminhtml_Customer_Grid extends Mage_Adminht
 
     public function getGridUrl()
     {
+        if ($this->getOrder()) {
+            return $this->getUrl('*/*/customerGrid', array('order_id' => $this->getOrder()->getId()));
+        }
         return $this->getUrl('*/*/customerGrid');
     }
 }

--- a/app/code/local/Magpleasure/Assignorder/Model/Observer.php
+++ b/app/code/local/Magpleasure/Assignorder/Model/Observer.php
@@ -53,13 +53,13 @@ class Magpleasure_Assignorder_Model_Observer
         $block = $event->getBlock();
 
         # Order View
-        if ($block && ($block->getNameInLayout() == 'sales_order_edit')) {
+        if ($block && ($block->getNameInLayout() == 'sales_order_edit') && $this->_helper()->isAllowed()) {
             if ($block instanceof Mage_Adminhtml_Block_Sales_Order_View) {
 
                 /** @var Magpleasure_Assignorder_Model_Order $order */
                 $order = $this->_helper()->_order()->getOrder();
 
-                if ($order->isGuestOrder() && $this->_helper()->isAllowed()) {
+                if ($order->isGuestOrder()) {
 
                     $url = $this->_getBackendUrlModel()->getUrl('adminhtml/assignorder_order/customerSelect', array(
                         'order_id' => $order->getId(),
@@ -90,7 +90,7 @@ class Magpleasure_Assignorder_Model_Observer
 
     public function massActionOption($observer)
     {
-        if (!$this->_helper()->extEnabled()) {
+        if (!$this->_helper()->extEnabled() || !$this->_helper()->isAllowed()) {
             return;
         }
 


### PR DESCRIPTION
This PR ensures that if the "Per Website" account sharing is used that orders cannot be transferred across websites. It also fixes a bug where the order filter for single order assignments is lost when the grid is refreshed.